### PR TITLE
Drop series if projection and historic data both empty

### DIFF
--- a/src/witan/send/chart.clj
+++ b/src/witan/send/chart.clj
@@ -338,7 +338,7 @@
                                        :shape (-> domain-value colors-and-points :point)
                                        :projection-data (into [] (filter #(= domain-value (domain-key %))) projection-data)
                                        :historical-data (into [] (filter #(= domain-value (domain-key %))) historical-data)})))
-                        (remove #(empty? (:projection-data %))))
+                        (remove #(and (empty? (:historical-data %)) (empty? (:projection-data %)))))
                        domain-values))))
          (remove #(empty? (:series %)))
          (map comparison-chart-and-table))


### PR DESCRIPTION
I'd set this up to not do a chart if there was no projection data but it also meant it was causing historic charts to not be produced