### PR TITLE
Calculate and chart total population data from input

### DIFF
--- a/src/witan/send/chart.clj
+++ b/src/witan/send/chart.clj
@@ -326,7 +326,11 @@
           "min" "low 95pc bound" "q1" "median" "q3" "high 95pc bound" "max" "iqr"]]
         (comp
          (map (fn [{:keys [legend-label projection-data historical-data]}]
-                {:historical-data (into [] (map (fn [record] (assoc record :label legend-label))) historical-data)
+                {:historical-data (into [] (map (fn [record] (assoc record
+                                                                    :label legend-label
+                                                                    :academic-year (if (= 99 (:academic-year record))
+                                                                                     "Total"
+                                                                                     (:academic-year record))))) historical-data)
                  :projection-data (into [] (map (fn [record] (assoc record :label legend-label))) projection-data)}))
          (mapcat (juxt :historical-data :projection-data))
          cat
@@ -357,7 +361,10 @@
                        (comp
                         (map (fn [domain-value]
                                (merge serie-base-def
-                                      {:legend-label (get-in chart-base-def [:domain-values-lookup domain-value] domain-value)
+                                      {:legend-label (let [label (get-in chart-base-def [:domain-values-lookup domain-value] domain-value)]
+                                                       (if (= label 99)
+                                                         "Total"
+                                                         label))
                                        :color (-> domain-value colors-and-points :color)
                                        :shape (-> domain-value colors-and-points :point)
                                        :projection-data (into [] (filter #(= domain-value (domain-key %))) projection-data)

--- a/src/witan/send/vis/general_population.clj
+++ b/src/witan/send/vis/general_population.clj
@@ -37,7 +37,7 @@
    ["General Population NCY 15+" ay/ncy-15+]
    ["General Population All NCYs" (concat ay/early-years ay/key-stage-1 ay/key-stage-2 ay/key-stage-3 ay/key-stage-4 ay/key-stage-5 ay/ncy-15+)]
    ["Total General Population" #{99}]
-   ;; 99 is used as a placeholder where data structures require a number be present but is
+   ;; FIXME: 99 is used as a placeholder where data structures require a number be present but is
    ;; converted to a more informative string ("Total") when outputting to a chart and spreadsheet
    ])
 
@@ -47,7 +47,7 @@
         (fn [[grp-key values]]
           {:calendar-year grp-key
            :academic-year 99
-           ;; 99 is used as a placeholder where data structures require a number be present but is
+           ;; FIXME: 99 is used as a placeholder where data structures require a number be present but is
            ;; converted to a more informative string ("Total") when outputting to a chart and spreadsheet
            :population (reduce + (map :population values))}))
        (sort-by :calendar-year)))
@@ -61,7 +61,7 @@
                          :serie-base-def base-gp-serie-def
                          :colors-and-points (merge (wsc/domain-colors-and-points domain-key historical-data)
                                                    {99 {:color [152.0 223.0 138.0 255.0], :point \V}})
-                         ;; 99 is used as a placeholder where data structures require a number be present but is
+                         ;; FIXME: 99 is used as a placeholder where data structures require a number be present but is
                          ;; converted to a more informative string ("Total") when outputting to a chart and spreadsheet
                          :historical-data (concat historical-data
                                                   (sum-population historical-data))}

--- a/src/witan/send/vis/general_population.clj
+++ b/src/witan/send/vis/general_population.clj
@@ -35,7 +35,17 @@
    ["General Population Key Stage 4" ay/key-stage-4]
    ["General Population Key Stage 5" ay/key-stage-5]
    ["General Population NCY 15+" ay/ncy-15+]
-   ["General Population All NCYs" (concat ay/early-years ay/key-stage-1 ay/key-stage-2 ay/key-stage-3 ay/key-stage-4 ay/key-stage-5 ay/ncy-15+)]])
+   ["General Population All NCYs" (concat ay/early-years ay/key-stage-1 ay/key-stage-2 ay/key-stage-3 ay/key-stage-4 ay/key-stage-5 ay/ncy-15+)]
+   ["Total General Population" #{99}]])
+
+(defn sum-population [pop-data]
+  (->> (group-by :calendar-year pop-data)
+       (map
+        (fn [[grp-key values]]
+          {:calendar-year grp-key
+           :academic-year 99
+           :population (reduce + (map :population values))}))
+       (sort-by :calendar-year)))
 
 ;; FIXME: Not terribly happy about calling this "historic data" as it is a projection
 (defn charts
@@ -44,8 +54,10 @@
      (wsc/domain-charts {:domain-key domain-key
                          :chart-base-def (base-gp-chart-def ay-lookup)
                          :serie-base-def base-gp-serie-def
-                         :colors-and-points (wsc/domain-colors-and-points domain-key historical-data)
-                         :historical-data historical-data}
+                         :colors-and-points (merge (wsc/domain-colors-and-points domain-key historical-data)
+                                                   {99 {:color [152.0 223.0 138.0 255.0], :point \V}})
+                         :historical-data (concat historical-data
+                                                  (sum-population historical-data))}
                         titles-and-sets)))
   ([historical-data]
    (charts ay/ay-lookup

--- a/src/witan/send/vis/general_population.clj
+++ b/src/witan/send/vis/general_population.clj
@@ -36,7 +36,10 @@
    ["General Population Key Stage 5" ay/key-stage-5]
    ["General Population NCY 15+" ay/ncy-15+]
    ["General Population All NCYs" (concat ay/early-years ay/key-stage-1 ay/key-stage-2 ay/key-stage-3 ay/key-stage-4 ay/key-stage-5 ay/ncy-15+)]
-   ["Total General Population" #{99}]])
+   ["Total General Population" #{99}]
+   ;; 99 is used as a placeholder where data structures require a number be present but is
+   ;; converted to a more informative string ("Total") when outputting to a chart and spreadsheet
+   ])
 
 (defn sum-population [pop-data]
   (->> (group-by :calendar-year pop-data)
@@ -44,6 +47,8 @@
         (fn [[grp-key values]]
           {:calendar-year grp-key
            :academic-year 99
+           ;; 99 is used as a placeholder where data structures require a number be present but is
+           ;; converted to a more informative string ("Total") when outputting to a chart and spreadsheet
            :population (reduce + (map :population values))}))
        (sort-by :calendar-year)))
 
@@ -56,6 +61,8 @@
                          :serie-base-def base-gp-serie-def
                          :colors-and-points (merge (wsc/domain-colors-and-points domain-key historical-data)
                                                    {99 {:color [152.0 223.0 138.0 255.0], :point \V}})
+                         ;; 99 is used as a placeholder where data structures require a number be present but is
+                         ;; converted to a more informative string ("Total") when outputting to a chart and spreadsheet
                          :historical-data (concat historical-data
                                                   (sum-population historical-data))}
                         titles-and-sets)))


### PR DESCRIPTION
The magic number (99) is used as a placeholder where data structures require a number be present but is converted to a more informative string ("Total") when outputting to a chart and spreadsheet